### PR TITLE
Simplify `StateObject.Dependency`

### DIFF
--- a/Sources/_SwiftUIDependency/StateObjectDependency.swift
+++ b/Sources/_SwiftUIDependency/StateObjectDependency.swift
@@ -28,11 +28,7 @@
       /// Creates a new state object with an initial wrapped value.
       public init(wrappedValue: @escaping @autoclosure () -> ObjectType) {
         self._object = withEscapedDependencies { continuation in
-          StateObject(wrappedValue: {
-            continuation.yield {
-              wrappedValue()
-            }
-          }())
+          StateObject(wrappedValue: continuation.yield { wrappedValue() })
         }
       }
       /// The underlying value referenced by the state object.

--- a/Sources/_SwiftUIDependency/StateObjectDependency.swift
+++ b/Sources/_SwiftUIDependency/StateObjectDependency.swift
@@ -28,11 +28,11 @@
       /// Creates a new state object with an initial wrapped value.
       public init(wrappedValue: @escaping @autoclosure () -> ObjectType) {
         self._object = withEscapedDependencies { continuation in
-            StateObject(wrappedValue: {
-              continuation.yield {
-                wrappedValue()
-              }
-            }())
+          StateObject(wrappedValue: {
+            continuation.yield {
+              wrappedValue()
+            }
+          }())
         }
       }
       /// The underlying value referenced by the state object.


### PR DESCRIPTION
The implementation of `StateObject.Dependency` was overly complex to work around a limitation of an earlier variant of `withEscapedDependencies` that didn't produce a result. The API that finally shipped with `Dependencies` allows to refactor this initializer and use `withEscapedDependencies` directly.
This was spotted and reported on Slack by @kabiroberai. Thanks!