### PR TITLE
Remove `Logger`'s dependency to `BundleInfo`

### DIFF
--- a/Sources/LoggerDependency/Logger.swift
+++ b/Sources/LoggerDependency/Logger.swift
@@ -39,11 +39,10 @@
     /// logger.log("Paid with bank account \(accountNumber)")
     /// ```
     public subscript(subsystem subsystem: String, category category: String) -> Logger {
-      return Logger(subsystem: subsystem, category: category)
+      Logger(subsystem: subsystem, category: category)
     }
     /// Creates a `Logger` value where messages are categorized by the provided argument.
-    /// The `Logger`'s subsystem is the bundle identifier, extracted from the ``BundleInfo``
-    /// dependency.
+    /// The `Logger`'s subsystem is the bundle identifier.
     ///
     /// You can use this subscript on the `\.logger` dependency:
     /// ```swift
@@ -52,8 +51,7 @@
     /// logger.log("Paid with bank account \(accountNumber)")
     /// ```
     public subscript(category: String) -> Logger {
-      @Dependency(\.bundleInfo) var bundleInfo
-      return Logger(subsystem: bundleInfo.bundleIdentifier, category: category)
+      Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: category)
     }
   }
 #endif


### PR DESCRIPTION
The dependency of `Logger` to `BundleInfo` doesn't bring much to the table, and is mostly annoying when testing, as it requires to provide an additional value for `BundleInfo` when testing models that using categorized loggers like:
```swift
@Dependency(\.logger["MyCategory"]) var logger
```

The `Logger` dependency now uses `Bundle.main` directly, so you only need to provide a `Logger` value when testing.
This shouldn't break any existing setup, but in any case, feel free to open an issue/discussion.

@iampatbrown has interesting ideas to improve the discoverability of the subsystem/category variants using some `@Dependency`'s overload, but it will probably require to deprecate these `Logger` subscripts to keep the API surface in check, so it may come in a second round.

This should fix #38.