### PR TITLE
Avoid deadlock when initializing default value of PersistentContainer

### DIFF
--- a/Sources/PersistentContainerDependency/PersistentContainer.swift
+++ b/Sources/PersistentContainerDependency/PersistentContainer.swift
@@ -61,7 +61,6 @@
           print("Failed to load PesistentStore: \(error)")
         }
       })
-      persistentContainer.viewContext.automaticallyMergesChangesFromParent = true
       return .init(persistentContainer)
     }
   }


### PR DESCRIPTION
Sorry for my late reply. I was busy before. Your fix almost works. But the problem is that the live and preview value use the default static func, which still accesses viewContext during initialization. Removing this line fixes it and the configuration should still happen later in the closure then.