### PR TITLE
Lazily configure `PersistentContainer`'s `viewContext` on first access to avoid potential deadlocks

### DIFF
--- a/Sources/PersistentContainerDependency/PersistentContainer.swift
+++ b/Sources/PersistentContainerDependency/PersistentContainer.swift
@@ -74,13 +74,26 @@
 
     public init(_ persistentContainer: NSPersistentContainer) {
       let persistentContainer = UncheckedSendable(persistentContainer)
-      self._viewContext = { persistentContainer.viewContext }
+      let isViewContextConfigured = LockIsolated(false)
+      
+      let viewContext = { @Sendable in
+        let context = persistentContainer.viewContext
+        isViewContextConfigured.withValue { isConfigured in
+          if !isConfigured {
+            context.automaticallyMergesChangesFromParent = true
+            isConfigured = true
+          }
+        }
+        return context
+      }
+      
+      self._viewContext = viewContext
       self._newBackgroundContext = {
         persistentContainer.wrappedValue.newBackgroundContext()
       }
       self._newChildViewContext = {
         let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = persistentContainer.viewContext
+        context.parent = viewContext()
         return context
       }
     }

--- a/Sources/PersistentContainerDependency/PersistentContainer.swift
+++ b/Sources/PersistentContainerDependency/PersistentContainer.swift
@@ -61,7 +61,6 @@
           print("Failed to load PesistentStore: \(error)")
         }
       })
-      persistentContainer.viewContext.automaticallyMergesChangesFromParent = true
       return .init(persistentContainer)
     }
   }


### PR DESCRIPTION
This sets the `automaticallyMergesChangesFromParent` flag on `viewContext`'s first access instead of eagerly doing it when the persistent container is created, as this shown to be a potential source of deadlock in certain configurations.
Thanks @KaiOelfke for spotting the issue and fixing the workaround.