### PR TITLE
Make `PersistentContainer` initialization more flexible

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "e49dfe4d9e4c5c06f3334361360b801aef41631c",
-        "version" : "0.1.1"
+        "revision" : "98650d886ec950b587d671261f06d6b59dec4052",
+        "version" : "0.4.1"
       }
     },
     {
@@ -32,7 +32,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
       }
     },
@@ -41,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a9daebf0bf65981fd159c885d504481a65a75f02",
-        "version" : "0.8.0"
+        "revision" : "4af50b38daf0037cfbab15514a241224c3f62f98",
+        "version" : "0.8.5"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -300,6 +300,9 @@ let package = Package(
       name: "PersistentContainerDependencyTests",
       dependencies: [
         "PersistentContainerDependency"
+      ],
+      resources: [
+        .process("Model.xcdatamodeld")
       ]
     ),
 

--- a/Sources/PersistentContainerDependency/PersistentContainer.swift
+++ b/Sources/PersistentContainerDependency/PersistentContainer.swift
@@ -38,7 +38,13 @@
   }
 
   extension PersistentContainer {
-    /// Returns a ``PersistentContainer`` value.
+    /// Returns a ``PersistentContainer`` value corresponding to the first managed object model it
+    /// finds in the `.main` bundle.
+    public static func `default`(inMemory: Bool = false) -> PersistentContainer {
+      PersistentContainer(inMemory: inMemory)
+    }
+
+    /// Creates a ``PersistentContainer`` value.
     ///
     /// - Parameters:
     ///   - name: The name of the CoreData model, without extension. If you specify `nil` (the
@@ -48,11 +54,11 @@
     ///   without writing to disk. You typically set this flag to `true` when testing.
     ///
     /// - Returns: A ``PersistentContainer`` value
-    public static func `default`(
+    public init(
       name: String? = nil,
       bundle: Bundle = .main,
       inMemory: Bool = false
-    ) -> PersistentContainer {
+    ) {
       var name = name ?? bundle.object(forInfoDictionaryKey: "CFBundleName") as? String ?? ""
       let managedObjectModel: NSManagedObjectModel
       if let url = bundle.url(forResource: name, withExtension: "momd"),
@@ -76,7 +82,8 @@
       )
 
       guard !persistentContainer.persistentStoreDescriptions.isEmpty else {
-        return .init(persistentContainer)
+        self = .init(persistentContainer)
+        return
       }
       if inMemory {
         persistentContainer.persistentStoreDescriptions.first!.url = URL(
@@ -87,7 +94,7 @@
           print("Failed to load PesistentStore: \(error)")
         }
       })
-      return .init(persistentContainer)
+      self = .init(persistentContainer)
     }
   }
 

--- a/Sources/PersistentContainerDependency/PersistentContainer.swift
+++ b/Sources/PersistentContainerDependency/PersistentContainer.swift
@@ -97,8 +97,9 @@
     }
   }
 
-  // Models are cached, and loading the same model twice is ambiguous, so we cache the models to
-  // return them again if possible
+  // Managed object models are cached, and loading the same model twice is ambiguous, so we keep a
+  // trace of the models we loaded to return them again if possible. This is especially true when
+  // testing.
   private let loadedModels = LockIsolated([URL: UncheckedSendable<NSManagedObjectModel?>]())
   private func loadManagedObjectModel(url: URL) -> NSManagedObjectModel? {
     if let model = loadedModels.value[url]?.wrappedValue {

--- a/Tests/PersistentContainerDependencyTests/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Tests/PersistentContainerDependencyTests/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22C65" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="value" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+</model>

--- a/Tests/PersistentContainerDependencyTests/PersistentContainerTests.swift
+++ b/Tests/PersistentContainerDependencyTests/PersistentContainerTests.swift
@@ -10,7 +10,7 @@
     static let model: NSManagedObjectModel? = {
       let url = Bundle.module
         .url(forResource: "Model", withExtension: "momd")
-      return NSManagedObjectModel(contentsOf: url!)!
+      return url.flatMap(NSManagedObjectModel.init(contentsOf:))
     }()
 
     var newPersistentContainer: NSPersistentContainer? {

--- a/Tests/PersistentContainerDependencyTests/PersistentContainerTests.swift
+++ b/Tests/PersistentContainerDependencyTests/PersistentContainerTests.swift
@@ -1,6 +1,45 @@
-import Dependencies
-import PersistentContainerDependency
-import XCTest
+#if canImport(CoreData)
+  import Dependencies
+  import PersistentContainerDependency
+  import XCTest
+  import CoreData
 
-final class PersistentContainerTests: XCTestCase {
-}
+  final class PersistentContainerTests: XCTestCase {
+    @Dependency(\.persistentContainer) var persistentContainer
+
+    static let model: NSManagedObjectModel = {
+      let url = Bundle.module
+        .url(forResource: "Model", withExtension: "momd")
+      return NSManagedObjectModel(contentsOf: url!)!
+    }()
+
+    var newPersistentContainer: NSPersistentContainer {
+      .init(name: "Model", managedObjectModel: Self.model)
+    }
+
+    func testPersistentContainerIsGeneratingViewContext() {
+      withDependencies {
+        $0.persistentContainer = .init(self.newPersistentContainer, inMemory: true)
+      } operation: {
+        let viewContext = self.persistentContainer.viewContext
+        XCTAssertEqual(viewContext.concurrencyType, .mainQueueConcurrencyType)
+      }
+    }
+    func testPersistentContainerIsGeneratingNewViewContext() {
+      withDependencies {
+        $0.persistentContainer = .init(self.newPersistentContainer, inMemory: true)
+      } operation: {
+        let viewContext = self.persistentContainer.newChildViewContext()
+        XCTAssertEqual(viewContext.concurrencyType, .mainQueueConcurrencyType)
+      }
+    }
+    func testPersistentContainerIsGeneratingNewBackgroundContext() {
+      withDependencies {
+        $0.persistentContainer = .init(self.newPersistentContainer, inMemory: true)
+      } operation: {
+        let viewContext = self.persistentContainer.newBackgroundContext()
+        XCTAssertEqual(viewContext.concurrencyType, .privateQueueConcurrencyType)
+      }
+    }
+  }
+#endif

--- a/Tests/PersistentContainerDependencyTests/PersistentContainerTests.swift
+++ b/Tests/PersistentContainerDependencyTests/PersistentContainerTests.swift
@@ -7,35 +7,53 @@
   final class PersistentContainerTests: XCTestCase {
     @Dependency(\.persistentContainer) var persistentContainer
 
-    static let model: NSManagedObjectModel = {
+    static let model: NSManagedObjectModel? = {
       let url = Bundle.module
         .url(forResource: "Model", withExtension: "momd")
       return NSManagedObjectModel(contentsOf: url!)!
     }()
 
-    var newPersistentContainer: NSPersistentContainer {
-      .init(name: "Model", managedObjectModel: Self.model)
+    var newPersistentContainer: NSPersistentContainer? {
+      Self.model.map { .init(name: "Model", managedObjectModel: $0) }
     }
 
     func testPersistentContainerIsGeneratingViewContext() {
+      guard let newPersistentContainer else {
+        print(
+          "Warning, testPersistentContainerIsGeneratingViewContext is not executed in this context"
+        )
+        return
+      }
       withDependencies {
-        $0.persistentContainer = .init(self.newPersistentContainer, inMemory: true)
+        $0.persistentContainer = .init(newPersistentContainer, inMemory: true)
       } operation: {
         let viewContext = self.persistentContainer.viewContext
         XCTAssertEqual(viewContext.concurrencyType, .mainQueueConcurrencyType)
       }
     }
     func testPersistentContainerIsGeneratingNewViewContext() {
+      guard let newPersistentContainer else {
+        print(
+          "Warning, testPersistentContainerIsGeneratingNewViewContext is not executed in this context"
+        )
+        return
+      }
       withDependencies {
-        $0.persistentContainer = .init(self.newPersistentContainer, inMemory: true)
+        $0.persistentContainer = .init(newPersistentContainer, inMemory: true)
       } operation: {
         let viewContext = self.persistentContainer.newChildViewContext()
         XCTAssertEqual(viewContext.concurrencyType, .mainQueueConcurrencyType)
       }
     }
     func testPersistentContainerIsGeneratingNewBackgroundContext() {
+      guard let newPersistentContainer else {
+        print(
+          "Warning, testPersistentContainerIsGeneratingNewBackgroundContext is not executed in this context"
+        )
+        return
+      }
       withDependencies {
-        $0.persistentContainer = .init(self.newPersistentContainer, inMemory: true)
+        $0.persistentContainer = .init(newPersistentContainer, inMemory: true)
       } operation: {
         let viewContext = self.persistentContainer.newBackgroundContext()
         XCTAssertEqual(viewContext.concurrencyType, .privateQueueConcurrencyType)


### PR DESCRIPTION
This PR adds a `name` and a `bundle` argument to `PersistentContainer`'s initializer.