### PR TITLE
Depend on and import XCTestDynamicOverlay explicitly

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "0.4.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.8.0"),
   ],
   targets: [
 
@@ -53,6 +54,7 @@ let package = Package(
       name: "AccessibilityDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -66,6 +68,7 @@ let package = Package(
     .target(
       name: "ApplicationDependency",
       dependencies: [
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         "DependenciesAdditionsBasics",
       ]
@@ -81,6 +84,7 @@ let package = Package(
       name: "_AppStorageDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
         "UserDefaultsDependency",
       ]
@@ -95,7 +99,8 @@ let package = Package(
     .target(
       name: "AssertionDependency",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -109,6 +114,7 @@ let package = Package(
       name: "BundleDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -122,7 +128,8 @@ let package = Package(
     .target(
       name: "CodableDependency",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -135,7 +142,8 @@ let package = Package(
     .target(
       name: "CompressionDependency",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -187,13 +195,15 @@ let package = Package(
     .target(
       name: "DependenciesAdditionsBasics",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
 
     .testTarget(
       name: "DependenciesAdditionsBasicsTests",
       dependencies: [
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics"
       ]
     ),
@@ -201,7 +211,8 @@ let package = Package(
     .target(
       name: "DataDependency",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
 
@@ -217,6 +228,7 @@ let package = Package(
       name: "DeviceDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -232,6 +244,7 @@ let package = Package(
       name: "LoggerDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "BundleDependency",
       ]
     ),
@@ -264,7 +277,8 @@ let package = Package(
     .target(
       name: "NotificationCenterDependency",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
 
@@ -279,7 +293,8 @@ let package = Package(
     .target(
       name: "PathDependency",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
 
@@ -311,6 +326,7 @@ let package = Package(
       name: "ProcessInfoDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -356,6 +372,7 @@ let package = Package(
       name: "UserNotificationsDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),

--- a/Sources/AccessibilityDependency/AccessibilityDependency_iOS.swift
+++ b/Sources/AccessibilityDependency/AccessibilityDependency_iOS.swift
@@ -3,6 +3,7 @@
   @_spi(Internals) import DependenciesAdditionsBasics
   import Foundation
   import UIKit
+  import XCTestDynamicOverlay
 
   extension Accessibility: DependencyKey {
     public static var liveValue: Accessibility { .system }

--- a/Sources/CompressionDependency/Compressor.swift
+++ b/Sources/CompressionDependency/Compressor.swift
@@ -2,6 +2,7 @@
   import Compression
   import Dependencies
   import Foundation
+  import XCTestDynamicOverlay
 
   extension DependencyValues {
     /// A ``Compressor`` that can compress a `Data` value that you supply.

--- a/Sources/LoggerDependency/Logger.swift
+++ b/Sources/LoggerDependency/Logger.swift
@@ -8,6 +8,7 @@
   // now.
   // https://forums.swift.org/t/argument-must-be-a-static-method-or-property-of-oslogprivacy/38441/2
   @preconcurrency import OSLog
+  import XCTestDynamicOverlay
 
   @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
   extension DependencyValues {

--- a/Sources/PathDependency/PathDependency.swift
+++ b/Sources/PathDependency/PathDependency.swift
@@ -1,5 +1,6 @@
 import Dependencies
 import Foundation
+import XCTestDynamicOverlay
 
 extension Path: DependencyKey {
   /// An empty ``Path``

--- a/Sources/UserNotificationsDependency/UserNotificationsDependency.swift
+++ b/Sources/UserNotificationsDependency/UserNotificationsDependency.swift
@@ -2,6 +2,7 @@
   import Dependencies
   @_spi(Internals) import DependenciesAdditionsBasics
   @preconcurrency import UserNotifications
+  import XCTestDynamicOverlay
 
   extension DependencyValues {
     /// An abstraction of `UNUserNotificationCenter`, the central object for managing

--- a/Tests/DependenciesAdditionsBasicsTests/ProxiesTests.swift
+++ b/Tests/DependenciesAdditionsBasicsTests/ProxiesTests.swift
@@ -1,6 +1,7 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
 import XCTest
+import XCTestDynamicOverlay
 
 final class ProxiesTests: XCTestCase {
   func testReadWriteProxy() {


### PR DESCRIPTION
This is not required, but it can be a workaround for the build error below during dynamic linking `XCTestDynamicOverlay`.

We can work around this error by only adding `XCTestDynamicOverlay` to `DependenciesAdditionsBasics`, but it will be a workaround that should be deleted when this error is fixed.
So I think it may be better to depend on and import `XCTestDynamicOverlay` explicitly for clarity, and incidentally work around the error.
What do you think?

Steps for reproducing the error:
1. Create an application project
2. Add a (dynamic) framework target and embed it in the application target
3. Add `swift-dependencies` and link it to the framework target (this step will cause the linking to be dynamic)
4. Add `swift-dependencies-additions` and link it to the application target
5. Build the application target

<img width="803" alt="image" src="https://user-images.githubusercontent.com/7414906/237023225-88ee1d54-3383-4375-b698-5f428884dd41.png">