### PR TITLE
Expose NotificationCenter.Dependency.init publicly

### DIFF
--- a/Sources/NotificationCenterDependency/NotificationCenterDependency.swift
+++ b/Sources/NotificationCenterDependency/NotificationCenterDependency.swift
@@ -57,7 +57,7 @@
           Notification, Never
         >
 
-      init(
+      public init(
         @_inheritActorContext post: @escaping @Sendable (
           NSNotification.Name, AnyObject?, [AnyHashable: Any]?, StaticString, UInt
         ) -> Void,

--- a/Sources/NotificationCenterDependency/NotificationCenterDependency.swift
+++ b/Sources/NotificationCenterDependency/NotificationCenterDependency.swift
@@ -60,17 +60,16 @@
       public init(
         @_inheritActorContext post: @escaping @Sendable (
           NSNotification.Name, AnyObject?, [AnyHashable: Any]?, StaticString, UInt
-        ) -> Void,
+        ) -> Void = { _, _, _, _, _ in },
         @_inheritActorContext addObserver: @escaping @Sendable (
           AnyObject, Selector, NSNotification.Name?, AnyObject?, StaticString, UInt
-        ) -> Void,
+        ) -> Void = { _, _, _, _, _, _ in },
         @_inheritActorContext removeObserver: @escaping @Sendable (
           AnyObject, NSNotification.Name?, AnyObject?, StaticString, UInt
-        ) -> Void,
+        ) -> Void = { _, _, _, _, _ in },
         @_inheritActorContext publisher: @escaping @Sendable (
           Notification.Name, AnyObject?, StaticString, UInt
-        ) ->
-          AnyPublisher<Notification, Never>
+        ) -> AnyPublisher<Notification, Never> = { _, _, _, _ in Empty().eraseToAnyPublisher() }
       ) {
         self._post = post
         self._addObserver = addObserver


### PR DESCRIPTION
I think it's not very useful without the init that allows injection of members... For example, I'm trying to adjust it in tests so whenever I post some notification I expect something specific to happen.