### PR TITLE
Addressing Crashes with Non-Equatable Any Values

### DIFF
--- a/Sources/UserDefaultsDependency/UserDefaultsDependency.swift
+++ b/Sources/UserDefaultsDependency/UserDefaultsDependency.swift
@@ -300,16 +300,12 @@ extension UserDefaults.Dependency: TestDependencyKey {
 private func _isEqual(_ lhs: (any Sendable)?, _ rhs: (any Sendable)?) -> Bool {
   switch (lhs, rhs) {
   case let (.some(lhs), .some(rhs)):
-    return (lhs as! any Equatable).isEqual(other: rhs)
+      let lhs = try? PropertyListSerialization.data(fromPropertyList: lhs, format: .xml, options: .zero).base64EncodedString()
+      let rhs = try? PropertyListSerialization.data(fromPropertyList: rhs, format: .xml, options: .zero).base64EncodedString()
+    return lhs == rhs
   case (.none, .none):
     return type(of: lhs) == type(of: rhs)
   case (.some, .none), (.none, .some): return false
-  }
-}
-
-extension Equatable {
-  fileprivate func isEqual(other: Any) -> Bool {
-    self == other as? Self
   }
 }
 

--- a/Tests/UserDefaultsDependencyTests/UserDefaultsDependencyTests.swift
+++ b/Tests/UserDefaultsDependencyTests/UserDefaultsDependencyTests.swift
@@ -1,6 +1,6 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
-import UserDefaultsDependency
+@_spi(Internals) import UserDefaultsDependency
 import XCTest
 
 final class UserDefaultsDependencyTests: XCTestCase {
@@ -607,6 +607,20 @@ final class UserDefaultsDependencyTests: XCTestCase {
           userDefaults.set(7, forKey: "int")
         }
       }
+    }
+  }
+
+  func testUserDefaultsStoringArbitraryPlistRepresentableData() async {
+    @Dependency(\.userDefaults) var userDefaults: UserDefaults.Dependency
+
+    withDependencies {
+        $0.userDefaults = .ephemeral()
+    } operation: {
+      let data: [[String: Any]] = [["This": "is", "some": ["data": 123]]]
+      userDefaults.set([], forKey: "arbitraryDataKey")
+      userDefaults.set(data, forKey: "arbitraryDataKey")
+      let result: [[String: Any]]? = userDefaults.object(forKey: "arbitraryDataKey") as [[String: Any]]?
+      XCTAssertEqual(data.description, result?.description)
     }
   }
 }


### PR DESCRIPTION
## Description:

This pull request addresses an issue that was introduced in #53, where our codebase experienced crashes in tests for `Any` values that were not `Equatable`.

The root cause of these crashes is our usage of the library's internal properties, specifically the `set(_ object: Any, forKey: String)` function.

This pull request does not make the `set(_ object: Any, forKey: String)` function public. However, it serves as a first step towards considering this change. Making this function public could align the library with the functionality provided by native UserDefaults, keeping in mind that the responsibility for ensuring that objects are Plist-representable rests with the end user.
