### PR TITLE
Remove two deprecated `ProxyBindable` requirements

### DIFF
--- a/Sources/DependenciesAdditionsBasics/Proxies.swift
+++ b/Sources/DependenciesAdditionsBasics/Proxies.swift
@@ -490,16 +490,7 @@ public struct MainActorReadOnlyProxy<Value: Sendable>: Sendable {
 //@dynamicMemberLookup
 public protocol ProxyBindable {
   associatedtype Value
-  @available(*, deprecated, message: "Implement `getValueFunction()` instead")
-  var getValue: @Sendable () -> Value { get }
-  @available(*, deprecated, message: "Implement `setValueFunction()` instead")
-  var setValue: @Sendable (Value) -> Void { get }
-
-  /// This will be renamed `getValue` in the future when the deprecated `getValue` closure will be
-  /// removed.
   func getValueFunction() -> Value
-  /// This will be renamed `setValue` in the future when the deprecated `setValue` closure will be
-  /// removed.
   func setValueFunction(_ value: Value)
 }
 


### PR DESCRIPTION
Deprecation of these requirements could generate build-time warnings with `LockIsolated` that has a method with the same name. 
They were simply removed. If you were relying on them, you should rename `getValue` and `setValue` to `getValueFunction` and `setValueFunction` respectively. 
Quite ironically, we can't provide automatic fix-it for that!