### PR TITLE
Use storage.withValue closure return value to propagate valueDidChange

### DIFF
--- a/Sources/UserDefaultsDependency/UserDefaultsDependency.swift
+++ b/Sources/UserDefaultsDependency/UserDefaultsDependency.swift
@@ -272,12 +272,12 @@ extension UserDefaults.Dependency: TestDependencyKey {
     return UserDefaults.Dependency { key, _ in
       storage.value[key]
     } set: { value, key in
-      let valueDidChange = LockIsolated(false)
-      storage.withValue {
-        valueDidChange.setValue(!_isEqual($0[key], value))
+      let valueDidChange = storage.withValue {
+        let valueDidChange = !_isEqual($0[key], value)
         $0[key] = value
+        return valueDidChange
       }
-      if valueDidChange.value {
+      if valueDidChange {
         for continuation in continuations.value[key]?.values ?? [:].values {
           continuation.yield(value)
         }


### PR DESCRIPTION
In the end this implementation detail doesn't probably matter so much for ephemeral(). I am not sure, if you prefer the LockIsolated<Bool> approach or this.