### PR TITLE
Replace XCTestDynamicOverlay with IssueReporting

### DIFF
--- a/DependenciesAdditions.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DependenciesAdditions.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "5da6989aae464f324eef5c5b52bdb7974725ab81",
-        "version" : "1.0.0"
+        "revision" : "71344dd930fde41e8f3adafe260adcbb2fc2a3dc",
+        "version" : "1.5.4"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "ea631ce892687f5432a833312292b80db238186a",
-        "version" : "1.0.0"
+        "revision" : "bb5059bde9022d69ac516803f4f227d8ac967f71",
+        "version" : "1.1.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "edd66cace818e1b1c6f1b3349bb1d8e00d6f8b01",
-        "version" : "1.0.0"
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "cc26d06125dbc913c6d9e8a905a5db0b994509e0",
-        "version" : "1.3.5"
+        "revision" : "d7472be6b3c89251ce4c0db07d32405b43426781",
+        "version" : "1.3.7"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
-        "version" : "1.2.0"
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
+        "version" : "600.0.0-prerelease-2024-08-14"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swiftui-navigation",
       "state" : {
-        "revision" : "f5bcdac5b6bb3f826916b14705f37a3937c2fd34",
-        "version" : "1.0.0"
+        "revision" : "fc91d591ebba1f90d65028ccb65c861e5979e898",
+        "version" : "1.5.4"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "c6809a193975cab4d5308c64bd1d51e0df467928",
+        "version" : "1.2.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.3.5"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.2"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.2.3"),
   ],
   targets: [
 
@@ -53,7 +53,7 @@ let package = Package(
       name: "AccessibilityDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -67,7 +67,7 @@ let package = Package(
     .target(
       name: "ApplicationDependency",
       dependencies: [
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         .product(name: "Dependencies", package: "swift-dependencies"),
         "DependenciesAdditionsBasics",
       ]
@@ -83,7 +83,7 @@ let package = Package(
       name: "_AppStorageDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
         "UserDefaultsDependency",
       ]
@@ -99,7 +99,7 @@ let package = Package(
       name: "BundleDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -114,7 +114,7 @@ let package = Package(
       name: "CodableDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -128,7 +128,7 @@ let package = Package(
       name: "CompressionDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
     .testTarget(
@@ -180,14 +180,14 @@ let package = Package(
       name: "DependenciesAdditionsBasics",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
 
     .testTarget(
       name: "DependenciesAdditionsBasicsTests",
       dependencies: [
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -196,7 +196,7 @@ let package = Package(
       name: "DataDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
 
@@ -212,7 +212,7 @@ let package = Package(
       name: "DeviceDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -228,7 +228,7 @@ let package = Package(
       name: "LoggerDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "BundleDependency",
       ]
     ),
@@ -262,7 +262,7 @@ let package = Package(
       name: "NotificationCenterDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
 
@@ -278,7 +278,7 @@ let package = Package(
       name: "PathDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]
     ),
 
@@ -310,7 +310,7 @@ let package = Package(
       name: "ProcessInfoDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),
@@ -356,7 +356,7 @@ let package = Package(
       name: "UserNotificationsDependency",
       dependencies: [
         .product(name: "Dependencies", package: "swift-dependencies"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
+        .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
         "DependenciesAdditionsBasics",
       ]
     ),

--- a/Sources/AccessibilityDependency/AccessibilityDependency_iOS.swift
+++ b/Sources/AccessibilityDependency/AccessibilityDependency_iOS.swift
@@ -3,7 +3,7 @@
   @_spi(Internals) import DependenciesAdditionsBasics
   import Foundation
   import UIKit
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   extension Accessibility: DependencyKey {
     public static var liveValue: Accessibility { .system }

--- a/Sources/ApplicationDependency/ApplicationDependency_iOS.swift
+++ b/Sources/ApplicationDependency/ApplicationDependency_iOS.swift
@@ -1,7 +1,7 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 #if os(iOS)
   @preconcurrency import UIKit

--- a/Sources/ApplicationDependency/ApplicationDependency_tvOS.swift
+++ b/Sources/ApplicationDependency/ApplicationDependency_tvOS.swift
@@ -1,7 +1,7 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 #if os(tvOS)
   @preconcurrency import UIKit

--- a/Sources/BundleDependency/BundleInfo.swift
+++ b/Sources/BundleDependency/BundleInfo.swift
@@ -1,7 +1,7 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 extension DependencyValues {
   public var bundleInfo: BundleInfo {

--- a/Sources/CodableDependency/DataDecoder.swift
+++ b/Sources/CodableDependency/DataDecoder.swift
@@ -1,6 +1,6 @@
 import Dependencies
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 extension DependencyValues {
   /// A ``DataDecoder`` that can encode a `Codable` value into a `Data` value.

--- a/Sources/CodableDependency/DataEncoder.swift
+++ b/Sources/CodableDependency/DataEncoder.swift
@@ -1,6 +1,6 @@
 import Dependencies
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 extension DependencyValues {
   /// A ``DataEncoder`` that can encode a `Codable` value into a `Data` value.

--- a/Sources/CompressionDependency/Compressor.swift
+++ b/Sources/CompressionDependency/Compressor.swift
@@ -2,7 +2,7 @@
   import Compression
   import Dependencies
   import Foundation
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   extension DependencyValues {
     /// A ``Compressor`` that can compress a `Data` value that you supply.

--- a/Sources/DataDependency/DataDependency.swift
+++ b/Sources/DataDependency/DataDependency.swift
@@ -1,6 +1,6 @@
 import Dependencies
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 /// This dependency is inspired by [David Roman](https://github.com/davdroman)'s PR:
 /// https://github.com/pointfreeco/swift-composable-architecture/pull/1648
@@ -134,7 +134,7 @@ extension DataReader {
   }
   public static var unimplemented: DataReader {
     .init(
-      contentsOfURL: XCTestDynamicOverlay.unimplemented(#"@Dependency(\.dataReader.contentsOfURL)"#)
+      contentsOfURL: IssueReporting.unimplemented(#"@Dependency(\.dataReader.contentsOfURL)"#)
     )
   }
 }
@@ -147,7 +147,7 @@ extension DataWriter {
   }
   public static var unimplemented: DataWriter {
     .init(
-      writeToURL: XCTestDynamicOverlay.unimplemented(#"@Dependency(\.dataWriter.writeToURL)"#)
+      writeToURL: IssueReporting.unimplemented(#"@Dependency(\.dataWriter.writeToURL)"#)
     )
   }
 }

--- a/Sources/DependenciesAdditionsBasics/Internal/RuntimeWarnings.swift
+++ b/Sources/DependenciesAdditionsBasics/Internal/RuntimeWarnings.swift
@@ -59,7 +59,7 @@ func runtimeWarn(
 }
 
 #if DEBUG
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   #if canImport(os)
     import os

--- a/Sources/DependenciesAdditionsBasics/Proxies+Unimplemented.swift
+++ b/Sources/DependenciesAdditionsBasics/Proxies+Unimplemented.swift
@@ -1,4 +1,5 @@
 import Dependencies
+import IssueReporting
 
 extension ReadWriteBinding {
   @available(*, unavailable, message: "Use .unimplemented(_:placeholder:)")
@@ -9,7 +10,7 @@ extension ReadWriteBinding {
     line: UInt = #line
   ) -> Self where Value: Sendable {
     let value = LockIsolated<@Sendable () -> Value>(
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: () as! Value,
         fileID: fileID,
@@ -31,7 +32,7 @@ extension ReadWriteBinding {
     line: UInt = #line
   ) -> Self where Value: Sendable {
     let value = LockIsolated<@Sendable () -> Value>(
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: placeholder(),
         fileID: fileID,
@@ -90,7 +91,7 @@ extension ReadOnlyProxy {
     line: UInt = #line
   ) -> Self {
     ReadOnlyProxy(
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: () as! Value,
         fileID: fileID,
@@ -105,7 +106,7 @@ extension ReadOnlyProxy {
     line: UInt = #line
   ) -> Self {
     ReadOnlyProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: placeholder,
         fileID: fileID,
@@ -124,7 +125,7 @@ extension MainActorReadWriteBinding {
     line: UInt = #line
   ) -> Self where Value: Sendable {
     let value = LockIsolated<@Sendable () -> Value>(
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: () as! Value,
         fileID: fileID,
@@ -146,7 +147,7 @@ extension MainActorReadWriteBinding {
     line: UInt = #line
   ) -> Self where Value: Sendable {
     let value = LockIsolated<@Sendable () -> Value>(
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: placeholder(),
         fileID: fileID,
@@ -206,7 +207,7 @@ extension MainActorReadOnlyProxy {
   ) -> Self {
     MainActorReadOnlyProxy(
       value:
-        XCTestDynamicOverlay.unimplemented(
+        IssueReporting.unimplemented(
           description,
           placeholder: () as! Value,
           fileID: fileID,
@@ -221,7 +222,7 @@ extension MainActorReadOnlyProxy {
     line: UInt = #line
   ) -> Self {
     MainActorReadOnlyProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: placeholder,
         fileID: fileID,
@@ -238,7 +239,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable () -> Result {
     FunctionProxy(value: {
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -252,7 +253,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -266,7 +267,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -280,7 +281,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -295,7 +296,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -310,7 +311,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D, E) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -326,7 +327,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: placeholder,
         fileID: fileID,
@@ -345,7 +346,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable () async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -360,7 +361,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -375,7 +376,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -390,7 +391,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -405,7 +406,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -420,7 +421,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D, E) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -438,7 +439,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable () throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -451,7 +452,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -464,7 +465,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -477,7 +478,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -491,7 +492,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -505,7 +506,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D, E) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -522,7 +523,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable () async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -535,7 +536,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -548,7 +549,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -561,7 +562,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -575,7 +576,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -589,7 +590,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @Sendable (A, B, C, D, E) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -606,7 +607,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable () -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -622,7 +623,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -638,7 +639,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -654,7 +655,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -670,7 +671,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -685,7 +686,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D, E) -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -704,7 +705,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable () async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -719,7 +720,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -734,7 +735,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -749,7 +750,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -764,7 +765,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -779,7 +780,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D, E) async -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         placeholder: fatalError(),
         fileID: fileID,
@@ -797,7 +798,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable () throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -810,7 +811,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -823,7 +824,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -836,7 +837,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -850,7 +851,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -864,7 +865,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D, E) throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -881,7 +882,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable () async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -894,7 +895,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -907,7 +908,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -920,7 +921,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -934,7 +935,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line
@@ -948,7 +949,7 @@ extension FunctionProxy {
     line: UInt = #line
   ) -> Self where Value == @MainActor @Sendable (A, B, C, D, E) async throws -> Result {
     FunctionProxy({
-      XCTestDynamicOverlay.unimplemented(
+      IssueReporting.unimplemented(
         description,
         fileID: fileID,
         line: line

--- a/Sources/DependenciesAdditionsBasics/TestSupport/WithTimeout.swift
+++ b/Sources/DependenciesAdditionsBasics/TestSupport/WithTimeout.swift
@@ -1,5 +1,5 @@
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 #if os(Linux)
   public let NSEC_PER_MSEC: UInt64 = 1_000_000

--- a/Sources/DeviceDependency/DeviceCheckDependency.swift
+++ b/Sources/DeviceDependency/DeviceCheckDependency.swift
@@ -2,7 +2,7 @@
   import Dependencies
   @_spi(Internals) import DependenciesAdditionsBasics
   import DeviceCheck
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   extension DependencyValues {
     public var deviceCheckDevice: DeviceCheckDevice {

--- a/Sources/DeviceDependency/UIDeviceDependency_iOS.swift
+++ b/Sources/DeviceDependency/UIDeviceDependency_iOS.swift
@@ -1,7 +1,7 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 #if os(iOS)
   import UIKit.UIDevice

--- a/Sources/DeviceDependency/UIDeviceDependency_tvOS.swift
+++ b/Sources/DeviceDependency/UIDeviceDependency_tvOS.swift
@@ -1,7 +1,7 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 #if os(tvOS)
   import UIKit.UIDevice

--- a/Sources/DeviceDependency/WKInterfaceDeviceDependency.swift
+++ b/Sources/DeviceDependency/WKInterfaceDeviceDependency.swift
@@ -1,6 +1,6 @@
 import Dependencies
 @_spi(Internals) import DependenciesAdditionsBasics
-import XCTestDynamicOverlay
+import IssueReporting
 
 #if os(watchOS)
   import WatchKit.WKInterfaceDevice

--- a/Sources/LoggerDependency/Logger.swift
+++ b/Sources/LoggerDependency/Logger.swift
@@ -8,7 +8,7 @@
   // now.
   // https://forums.swift.org/t/argument-must-be-a-static-method-or-property-of-oslogprivacy/38441/2
   @preconcurrency import OSLog
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
   extension DependencyValues {

--- a/Sources/NotificationCenterDependency/NotificationCenterDependency.swift
+++ b/Sources/NotificationCenterDependency/NotificationCenterDependency.swift
@@ -2,7 +2,7 @@
   @preconcurrency import Combine
   import Dependencies
   import Foundation
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   extension DependencyValues {
     /// An abstraction of a `NotificationCenter`.
@@ -28,14 +28,14 @@
     /// reached.
     public static var unimplemented: Self {
       .init(
-        post: XCTestDynamicOverlay.unimplemented(
+        post: IssueReporting.unimplemented(
           #"@Dependency(\.notificationCenter.post)"#),
-        addObserver: XCTestDynamicOverlay.unimplemented(
+        addObserver: IssueReporting.unimplemented(
           #"@Dependency(\.notificationCenter.addObserver)"#,
           placeholder: { @Sendable _, _, _, _, _, _ in () }),
-        removeObserver: XCTestDynamicOverlay.unimplemented(
+        removeObserver: IssueReporting.unimplemented(
           #"@Dependency(\.notificationCenter.removeObserver)"#),
-        publisher: XCTestDynamicOverlay.unimplemented(
+        publisher: IssueReporting.unimplemented(
           #"@Dependency(\.notificationCenter.publisher)"#,
           placeholder: { @Sendable _, _, _, _ in Empty().eraseToAnyPublisher() })
       )

--- a/Sources/PathDependency/PathDependency.swift
+++ b/Sources/PathDependency/PathDependency.swift
@@ -1,6 +1,6 @@
 import Dependencies
 import Foundation
-import XCTestDynamicOverlay
+import IssueReporting
 
 extension Path: DependencyKey {
   /// An empty ``Path``
@@ -27,7 +27,7 @@ extension Path {
 
   /// An `unimplemented` that fails tests.
   public static var unimplemented: Path {
-    .init(XCTestDynamicOverlay.unimplemented(#"@Dependency(\.path)"#, placeholder: []))
+    .init(IssueReporting.unimplemented(#"@Dependency(\.path)"#, placeholder: []))
   }
 }
 

--- a/Sources/ProcessInfoDependency/ProcessInfoDependency.swift
+++ b/Sources/ProcessInfoDependency/ProcessInfoDependency.swift
@@ -2,7 +2,7 @@
   import Dependencies
   @_spi(Internals) import DependenciesAdditionsBasics
   import Foundation
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   extension DependencyValues {
     /// An abstraction of `ProcessInfo`, a collection of information about the current process.

--- a/Sources/UserNotificationsDependency/UserNotificationsDependency.swift
+++ b/Sources/UserNotificationsDependency/UserNotificationsDependency.swift
@@ -2,7 +2,7 @@
   import Dependencies
   @_spi(Internals) import DependenciesAdditionsBasics
   @preconcurrency import UserNotifications
-  import XCTestDynamicOverlay
+  import IssueReporting
 
   extension DependencyValues {
     /// An abstraction of `UNUserNotificationCenter`, the central object for managing

--- a/Sources/_AppStorageDependency/AppStorage.swift
+++ b/Sources/_AppStorageDependency/AppStorage.swift
@@ -2,7 +2,7 @@
 @_exported import DependenciesAdditionsBasics
 import Foundation
 @_spi(Internals) @_exported import UserDefaultsDependency
-import XCTestDynamicOverlay
+import IssueReporting
 
 extension Dependency {
   @propertyWrapper

--- a/Tests/DependenciesAdditionsBasicsTests/ProxiesTests.swift
+++ b/Tests/DependenciesAdditionsBasicsTests/ProxiesTests.swift
@@ -1,7 +1,7 @@
 //import Dependencies
 //@_spi(Internals) import DependenciesAdditionsBasics
 //import XCTest
-//import XCTestDynamicOverlay
+//import IssueReporting
 //
 //final class ProxiesTests: XCTestCase {
 //  func testReadWriteProxy() {
@@ -153,7 +153,7 @@
 //        }
 //      }
 //      let unimplemented = Foo(
-//        _implementation: .init(value: .init({ XCTestDynamicOverlay.unimplemented() })))
+//        _implementation: .init(value: .init({ IssueReporting.unimplemented() })))
 //      XCTExpectFailure {
 //        let _ = unimplemented.value(index: 4)
 //      }


### PR DESCRIPTION
The update of `XCTestDynamicOverlay` to `1.2.3` broke `Proxies+Unimplemented` adding the import fixed it.
Renamed all imports to `IssueReporting` and all calls of `unimplemented` to use `IssueReporting`